### PR TITLE
README: Add open in molab links

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ Guess what: the entire library can run in your browser !
 
 If you want a guided tour of how the library works, go here:
 
-[![](https://camo.githubusercontent.com/a282692dfebd373e3a0e43e39d1e412d356432c480f6240a4dd39d3122096580/68747470733a2f2f6d6172696d6f2e696f2f736869656c642e737667)](https://marimo.app/github.com/rambip/sketch-vectorization/blob/main/notebooks/walkthrough.py)
+[![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/rambip/sketch-vectorization/blob/main/notebooks/walkthrough.py/wasm)
 
 If you just want to test it for yourself, with your own drawings, go here:
 
-[![](https://camo.githubusercontent.com/a282692dfebd373e3a0e43e39d1e412d356432c480f6240a4dd39d3122096580/68747470733a2f2f6d6172696d6f2e696f2f736869656c642e737667)](https://marimo.app/github.com/rambip/sketch-vectorization/blob/main/notebooks/app.py)
+[![Open in molab](https://marimo.io/molab-shield.svg)](https://molab.marimo.io/github/rambip/sketch-vectorization/blob/main/notebooks/app.py/wasm)
 
 ## Install
 

--- a/notebooks/app.py
+++ b/notebooks/app.py
@@ -1,3 +1,10 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "sketchy-svg",
+#     "marimo",
+# ]
+# ///
 import marimo
 
 __generated_with = "0.20.1"
@@ -11,15 +18,12 @@ async def _():
     import marimo as mo
     import matplotlib.pyplot as plt
 
-    if find_spec("js"):
-        import micropip
-        await micropip.install("sketchy-svg")
+    from sketchy_svg import demo, load_normalized, sketch2svg
 
+    if find_spec("js"):
         from sketchy_svg import patch_onnx
 
         await patch_onnx()
-
-    from sketchy_svg import demo, load_normalized, sketch2svg
 
     return demo, load_normalized, mo, plt, sketch2svg
 

--- a/notebooks/app.py
+++ b/notebooks/app.py
@@ -11,12 +11,15 @@ async def _():
     import marimo as mo
     import matplotlib.pyplot as plt
 
-    from sketchy_svg import demo, load_normalized, sketch2svg
-
     if find_spec("js"):
+        import micropip
+        await micropip.install("sketchy-svg")
+
         from sketchy_svg import patch_onnx
 
         await patch_onnx()
+
+    from sketchy_svg import demo, load_normalized, sketch2svg
 
     return demo, load_normalized, mo, plt, sketch2svg
 


### PR DESCRIPTION
Hi @rambip; this is Akshay, one of the original creators of marimo. I stumbled upon your repo and found your awesome notebooks, and I wanted to make one small improvement to your README.

This PR replaces the marimo.app links with open in molab links. These links are still interactive, and just like marimo.app can be tried by users without any login. However, unlike marimo.app, the molab link allows users to save a copy of the notebook in their own workspace.

This PR also updates the `app.py` notebook to install `sketchy-svg` in WASM by default, so users don't see an error when opening the notebook.